### PR TITLE
Add a cloudwatch logs link for codedeploy notifications

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,7 @@ resource "aws_lambda_function" "notify_slack" {
       SLACK_CHANNEL     = "${var.slack_channel}"
       SLACK_USERNAME    = "${var.slack_username}"
       SLACK_EMOJI       = "${var.slack_emoji}"
+      LOG_GROUP         = "${var.log_group}"
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,11 @@ variable "slack_emoji" {
   default     = ":aws:"
 }
 
+variable "log_group" {
+  description = "Some alerts will include a link to cloudwatch logs, the log_group specified here will be used for filtering"
+  default     = "rock"
+}
+
 variable "kms_key_arn" {
   description = "ARN of the KMS key used for decrypting slack webhook url"
   default     = ""


### PR DESCRIPTION
This PR adds functionality to include a link to Cloud Watch logs as part of a Code Deploy notification. 

The generated link includes filtering for the specified `LOG_GROUP` and PRIORITY as well as filtering for only events within a time window around the deployment.